### PR TITLE
Add missing third S3 bucket for dogs picture! )

### DIFF
--- a/05-IAM-Accounts-AWS-Organizations/02_simple_identity_permissions_in_aws/demo_cfn.yaml
+++ b/05-IAM-Accounts-AWS-Organizations/02_simple_identity_permissions_in_aws/demo_cfn.yaml
@@ -43,9 +43,13 @@ Outputs:
   catpicsbucketname:
     Description: Bucketname for catpictures (the best animal!)
     Value: !Ref catpics
+  dogpicsbucketname:
+    Description: Bucketname for dogspictures (also best animal!)
+    Value: !Ref dogpics  
   animalpicsbucketname:
     Description: Bucketname for animalpics (the almost best animals!)
     Value: !Ref animalpics
   sallyusername:
     Description: IAM Username for Sally
     Value: !Ref sally
+    


### PR DESCRIPTION
According to the description, this template creates three S3 buckets, but there were only two in the template. I add the third S3 bucket for dogs picture. By the way, this inaccuracy is also appearing in the video lecture SAA-C02 & SAA-C03 course: [ASSOCIATE SHARED] [DEMO] Simple Identity Permissions in AWS [UPDATED202202]. You might of course correct the description, here you know better.